### PR TITLE
Add colorbar to the multiple xyz overlay plot

### DIFF
--- a/xyzoverlay.py
+++ b/xyzoverlay.py
@@ -645,7 +645,6 @@ if args.viewcba:
         #bonds
         for bonds in atom1_2_coord:
             ax.plot(*bonds.T,linewidth=np.log10(bond_scaler/num_atom_xyz),alpha=alpha_bonds,color='gray')
-    print("HI")
     #no axes
     ax.set_axis_off()
     #tight layout 


### PR DESCRIPTION
Hi Sebastian,

I’ve added a colorbar to facilitate the interpretation of the plot that arises from:
 
`python3 xyzoverlay.py multi-mol_trj.xyz -aa -vcm -cm coolwarm -ee H`

the new feature should appear by just adding the keyboard `-cb True`:

`python3 xyzoverlay.py multi-mol_trj.xyz -aa -vcm -cm coolwarm -cb True -ee H`
 
otherwise I think that it was not completely clear how many structures were considered in the plot. In my specific case, it is interesting to know how many steps did it take to optimize the molecular structure with quantum mechanics. Besides, it also helps to point towards the first and last structure, which could be a bit confusing without a color reference.

I hope it may be of interest and let me know if any adjustments are needed!

Best,
Enric